### PR TITLE
#5 user-service 회원가입 및 로그인 API 리펙토링

### DIFF
--- a/src/main/java/com/example/pomeserver/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/pomeserver/domain/user/controller/UserController.java
@@ -1,24 +1,32 @@
 package com.example.pomeserver.domain.user.controller;
 
+import com.example.pomeserver.domain.user.dto.request.UserSignInRequest;
 import com.example.pomeserver.global.dto.response.ApplicationResponse;
-import com.example.pomeserver.domain.user.dto.request.UserSaveRequest;
+import com.example.pomeserver.domain.user.dto.request.UserSignUpRequest;
 import com.example.pomeserver.domain.user.dto.response.UserResponse;
 import com.example.pomeserver.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RequestMapping("users")
+@RequestMapping("/users")
 @RestController
 public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/")
-    public ApplicationResponse<UserResponse> join(@ModelAttribute UserSaveRequest userSaveRequest){
-        return userService.create(userSaveRequest);
+    @PostMapping("/sign-up")
+    public ApplicationResponse<UserResponse> signUp(@RequestBody UserSignUpRequest request) {
+        UserResponse data = userService.signUp(request);
+        return ApplicationResponse.create("회원가입에 성공하셨습니다.", data);
+    }
+
+    @PostMapping("/sign-in")
+    public ApplicationResponse<UserResponse> signIn(@RequestBody UserSignInRequest request) {
+        UserResponse data = userService.signIn(request);
+        return ApplicationResponse.ok(data);
     }
 }

--- a/src/main/java/com/example/pomeserver/domain/user/dto/request/UserSignInRequest.java
+++ b/src/main/java/com/example/pomeserver/domain/user/dto/request/UserSignInRequest.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class UserLoginRequest{
-    private String userId;
+public class UserSignInRequest {
+    private String email;
     private String password;
 }

--- a/src/main/java/com/example/pomeserver/domain/user/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/example/pomeserver/domain/user/dto/request/UserSignUpRequest.java
@@ -1,14 +1,18 @@
 package com.example.pomeserver.domain.user.dto.request;
 
 import com.example.pomeserver.domain.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
 @NoArgsConstructor
 @Getter
-public class UserSaveRequest {
-    private String userId;
+@JsonInclude(Include.NON_NULL)
+public class UserSignUpRequest {
+    private String email;
     private String password;
     private String nickname;
     private String phoneNum;
@@ -20,9 +24,10 @@ public class UserSaveRequest {
 
     public User toEntity() {
         return User.builder()
-                .userId(this.userId)
-                .password(this.password)
-                .nickname(this.nickname)
-                .phoneNum(this.phoneNum).build();
+            .userId(UUID.randomUUID().toString())
+            .email(this.email)
+            .password(this.password)
+            .nickname(this.nickname)
+            .phoneNum(this.phoneNum).build();
     }
 }

--- a/src/main/java/com/example/pomeserver/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/pomeserver/domain/user/dto/response/UserResponse.java
@@ -18,7 +18,7 @@ public class UserResponse {
         userResponse.userId = user.getUserId();
         userResponse.nickName = user.getNickname();
         userResponse.phoneNum = user.getPhoneNum();
-        userResponse.imageURL = "test"; //TODO
+        userResponse.imageURL = "test"; //TO-DO
         return userResponse;
     }
 }

--- a/src/main/java/com/example/pomeserver/domain/user/entity/User.java
+++ b/src/main/java/com/example/pomeserver/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.example.pomeserver.domain.user.entity;
 
+import javax.persistence.Column;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,15 +19,20 @@ public class User {
     @GeneratedValue
     private Long id;
 
+    @Column(nullable = false, unique = true)
     private String userId;
+    @Column(nullable = false, unique = true)
+    private String email;
+    @Column(nullable = false, unique = true)
     private String password;
     private String nickname;
     private String phoneNum;
     private String image;
 
     @Builder
-    public User(String userId, String password, String nickname, String phoneNum, String image) {
+    public User(String userId, String email, String password, String nickname, String phoneNum, String image) {
         this.userId = userId;
+        this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.phoneNum = phoneNum;

--- a/src/main/java/com/example/pomeserver/domain/user/service/UserService.java
+++ b/src/main/java/com/example/pomeserver/domain/user/service/UserService.java
@@ -1,11 +1,10 @@
 package com.example.pomeserver.domain.user.service;
 
-import com.example.pomeserver.global.dto.response.ApplicationResponse;
-import com.example.pomeserver.domain.user.dto.request.UserLoginRequest;
-import com.example.pomeserver.domain.user.dto.request.UserSaveRequest;
+import com.example.pomeserver.domain.user.dto.request.UserSignInRequest;
+import com.example.pomeserver.domain.user.dto.request.UserSignUpRequest;
 import com.example.pomeserver.domain.user.dto.response.UserResponse;
 
 public interface UserService {
-    ApplicationResponse<UserResponse> create(UserSaveRequest userSaveRequest);
-    ApplicationResponse<UserResponse> login(UserLoginRequest userLoginRequest);
+    UserResponse signUp(UserSignUpRequest userSignUpRequest);
+    UserResponse signIn(UserSignInRequest userSignInRequest);
 }

--- a/src/main/java/com/example/pomeserver/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/pomeserver/domain/user/service/UserServiceImpl.java
@@ -2,8 +2,8 @@ package com.example.pomeserver.domain.user.service;
 
 import com.example.pomeserver.global.dto.response.ApplicationResponse;
 import com.example.pomeserver.global.util.SHA256Util;
-import com.example.pomeserver.domain.user.dto.request.UserLoginRequest;
-import com.example.pomeserver.domain.user.dto.request.UserSaveRequest;
+import com.example.pomeserver.domain.user.dto.request.UserSignInRequest;
+import com.example.pomeserver.domain.user.dto.request.UserSignUpRequest;
 import com.example.pomeserver.domain.user.dto.response.UserResponse;
 import com.example.pomeserver.domain.user.entity.User;
 import com.example.pomeserver.domain.user.exception.PasswordIsNotValid;
@@ -23,20 +23,26 @@ public class UserServiceImpl implements UserService{
 
     @Transactional
     @Override
-    public ApplicationResponse<UserResponse> create(UserSaveRequest userSaveRequest){
-        if(userRepository.findByUserId(userSaveRequest.getUserId()).isPresent())
-            throw new UserIdAlreadyExistException(userSaveRequest.getUserId());
-        userSaveRequest.setEncPassword(SHA256Util.encrypt(userSaveRequest.getPassword()));
-        User user = userRepository.save(userSaveRequest.toEntity());
-        return ApplicationResponse.create("회원가입 완료.", UserResponse.toDto(user));
+    public UserResponse signUp(UserSignUpRequest userSignUpRequest){
+        if(userRepository.findByUserId(userSignUpRequest.getEmail()).isPresent())
+            throw new UserIdAlreadyExistException(userSignUpRequest.getEmail());
+
+        userSignUpRequest.setEncPassword(SHA256Util.encrypt(userSignUpRequest.getPassword()));
+
+        User user = userRepository.save(userSignUpRequest.toEntity());
+
+        return UserResponse.toDto(user);
     }
 
+    @Transactional
     @Override
-    public ApplicationResponse<UserResponse> login(UserLoginRequest userLoginRequest) {
-        User user = userRepository.findByUserId(userLoginRequest.getUserId())
-                .orElseThrow(() -> new UserIdNotFound(userLoginRequest.getUserId()));
-        if(!user.getPassword().equals(SHA256Util.encrypt(userLoginRequest.getPassword())))
+    public UserResponse signIn(UserSignInRequest userSignInRequest) {
+        User user = userRepository.findByUserId(userSignInRequest.getEmail())
+                .orElseThrow(() -> new UserIdNotFound(userSignInRequest.getEmail()));
+
+        if(!user.getPassword().equals(SHA256Util.encrypt(userSignInRequest.getPassword())))
             throw new PasswordIsNotValid();
-        return ApplicationResponse.ok(UserResponse.toDto(user));
+
+        return UserResponse.toDto(user);
     }
 }


### PR DESCRIPTION
로직 작성 시, 명시적으로 작성해야 다른 분들이 보기에도 이해가 쉬울 거라 생각했습니다. 
그래서 UserController 에서 지역변수로 데이터를 받은 뒤, front로 넘겨줄 때 인자에 담는 식으로 구성하였습니다.
```` bash
    @PostMapping("/sign-up")
    public ApplicationResponse<UserResponse> signUp(@RequestBody UserSignUpRequest request) {
        UserResponse data = userService.signUp(request);
        return ApplicationResponse.create("회원가입에 성공하셨습니다.", data);
    }
````

회원가입과 로그인의 경우, uri 명과 함수명을 통상적으로 많이 사용되는 것으로 변경하였습니다. 이에 따라 DTO 클래스 명도 변경하였습니다.

User 엔티티에 email 컬럼을 추가하여, 로그인 시 사용하도록 하고 기존의 userId는 UUID 값으로 지정하여 unique key로 사용하면 어떨까 합니다.