### PR TITLE
#82 Goal 생성 시, goalCategoryId에서 Name으로 변경

### DIFF
--- a/src/main/java/com/example/pomeserver/domain/goal/dto/assembler/GoalCategoryAssembler.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/dto/assembler/GoalCategoryAssembler.java
@@ -1,16 +1,14 @@
 package com.example.pomeserver.domain.goal.dto.assembler;
 
-import com.example.pomeserver.domain.goal.dto.request.GoalCategoryCreateRequest;
-import com.example.pomeserver.domain.goal.dto.request.GoalCreateRequest;
 import com.example.pomeserver.domain.goal.entity.GoalCategory;
 import com.example.pomeserver.domain.user.entity.User;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GoalCategoryAssembler {
-  public GoalCategory toEntity(GoalCategoryCreateRequest request, User user) {
+  public GoalCategory toEntity(String name, User user) {
     return GoalCategory.builder()
-        .name(request.getName())
+        .name(name)
         .user(user)
         .build();
   }

--- a/src/main/java/com/example/pomeserver/domain/goal/dto/request/GoalCreateRequest.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/dto/request/GoalCreateRequest.java
@@ -14,8 +14,10 @@ import javax.validation.constraints.Size;
 @Data
 public class GoalCreateRequest {
 
-    @NotNull(message = "목표 카테고리 ID는 필수값입니다.")
-    private Long goalCategoryId;
+    @NotNull(message = "목표 카테고리는 필수값입니다.")
+    @NotBlank(message = "목표 카테고리 빈 문자열일 수 없습니다.")
+    @Size(max = 9, message = "목표 카테고리는 8자 이하만 가능합니다.")
+    private String name;
 
     //@Pattern(regexp = "(19|20)\\\\d{2}\\\\.((11|12)|(0?(\\\\d)))\\\\.(30|31|((0|1|2)?\\\\d))", message = "날짜의 패턴은 yyyy.mm.dd이어야 합니다.")
     @NotNull(message = "시작 날짜는 필수값입니다.")

--- a/src/main/java/com/example/pomeserver/domain/goal/repository/GoalCategoryRepository.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/repository/GoalCategoryRepository.java
@@ -3,15 +3,10 @@ package com.example.pomeserver.domain.goal.repository;
 import com.example.pomeserver.domain.goal.entity.GoalCategory;
 import com.example.pomeserver.domain.user.entity.User;
 import java.util.List;
-import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GoalCategoryRepository extends JpaRepository<GoalCategory, Long> {
   List<GoalCategory> findAllByUser(User user);
-
-  Optional<GoalCategory> findByNameAndUser(String name, User user);
 }

--- a/src/main/java/com/example/pomeserver/domain/goal/service/GoalCategoryServiceImpl.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/service/GoalCategoryServiceImpl.java
@@ -47,7 +47,7 @@ public class GoalCategoryServiceImpl implements GoalCategoryService {
         }
 
         // (3) 카테고리 생성
-        GoalCategory goalCategory = goalCategoryAssembler.toEntity(request, user);
+        GoalCategory goalCategory = goalCategoryAssembler.toEntity(request.getName(), user);
         GoalCategory saved = goalCategoryRepository.save(goalCategory);
 
         return ApplicationResponse.create("목표 카테고리를 생성했습니다.", GoalCategoryResponse.toDto(saved));


### PR DESCRIPTION
## Notice

프론트엔드 측 요청 사항에 따라 아래와 같이 변경하였습니다.

[요청사항]
목표 생성 시, 목표 카테고리 ID 값이 아닌 Name 값으로 생성

[변경사항]
1. 목표카테고리 생성 API는 그대로 두되, 목표 생성 API의 Request DTO 변경
2. 목표 생성 로직 내에서 목표 카테고리 생성 로직이 포함됨 
