### PR TITLE
[feature/goal-service] 사용자가 갖는 목표 전체 조회 API 기능 개발

### DIFF
--- a/src/main/java/com/example/pomeserver/domain/goal/controller/GoalController.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/controller/GoalController.java
@@ -65,12 +65,26 @@ public class GoalController {
      */
     @Auth
     @GetMapping("/category/{goalCategoryId}")
-    public ApplicationResponse<Page<GoalResponse>> findAllByUser(
+    public ApplicationResponse<Page<GoalResponse>> findAllByUserCategory(
             @UserId String userId,
             @PathVariable Long goalCategoryId,
             Pageable pageable)
     {
-        return goalService.findAllByUser(userId, goalCategoryId, pageable);
+        return goalService.findAllByUserCategory(userId, goalCategoryId, pageable);
+    }
+
+    /**
+     * 유저가 가진 Goal 전체 조회.
+     *
+     * @author 이은비
+     */
+    @Auth
+    @GetMapping("/users")
+    public ApplicationResponse<Page<GoalResponse>> findAllByUser(
+        @UserId String userId,
+        Pageable pageable)
+    {
+        return goalService.findAllByUser(userId, pageable);
     }
 
     /**

--- a/src/main/java/com/example/pomeserver/domain/goal/dto/response/GoalResponse.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/dto/response/GoalResponse.java
@@ -1,6 +1,8 @@
 package com.example.pomeserver.domain.goal.dto.response;
 
 import com.example.pomeserver.domain.goal.entity.Goal;
+import java.sql.Date;
+import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +16,8 @@ public class GoalResponse {
     private String oneLineMind;
     private int price;
     private Boolean isPublic;
+
+    private Boolean isEnd; // endDate가 지났거나 소비기록이 없거나
     private String nickname;
 
     public static GoalResponse toDto(Goal goal){
@@ -25,6 +29,12 @@ public class GoalResponse {
         response.oneLineMind = goal.getOneLineMind();
         response.price = goal.getPrice();
         response.isPublic = goal.isPublic();
+
+        if (LocalDate.parse(goal.getEndDate()).isBefore(LocalDate.now())) {
+            response.isEnd = true;
+        } else
+            response.isEnd = goal.getRecords().isEmpty();
+
         response.nickname = goal.getGoalCategory().getUser().getNickname();
         return response;
     }

--- a/src/main/java/com/example/pomeserver/domain/goal/entity/Goal.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/entity/Goal.java
@@ -3,6 +3,7 @@ package com.example.pomeserver.domain.goal.entity;
 import static javax.persistence.CascadeType.ALL;
 
 import com.example.pomeserver.domain.record.entity.Record;
+import com.example.pomeserver.domain.user.entity.User;
 import com.example.pomeserver.global.entity.DateBaseEntity;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +33,10 @@ public class Goal extends DateBaseEntity {
     @JoinColumn(name="goal_category_id")
     private GoalCategory goalCategory;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="id")
+    private User user;
+
     @OneToMany(mappedBy="goal", cascade=ALL)
     private List<Record> records = new ArrayList<>();
 
@@ -44,6 +49,11 @@ public class Goal extends DateBaseEntity {
     public void addRecord(Record record) {
         this.records.add(record);
     }
+    private void addUser(User user){
+        this.user = user;
+        user.addGoal(this);
+    }
+
 
     @Builder
     public Goal(GoalCategory goalCategory,
@@ -53,6 +63,7 @@ public class Goal extends DateBaseEntity {
                 int price,
                 boolean isPublic){
         this.addGoalCategory(goalCategory);
+        this.addUser(goalCategory.getUser());
         this.startDate = startDate;
         this.endDate = endDate;
         this.oneLineMind = oneLineMind;

--- a/src/main/java/com/example/pomeserver/domain/goal/repository/GoalRepository.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/repository/GoalRepository.java
@@ -13,4 +13,6 @@ import org.springframework.stereotype.Repository;
 public interface GoalRepository extends JpaRepository<Goal, Long> {
 
     Page<Goal> findAllByGoalCategory(GoalCategory goalCategory, Pageable pageable);
+
+    Page<Goal> findAllByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/example/pomeserver/domain/goal/service/GoalService.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/service/GoalService.java
@@ -12,10 +12,12 @@ public interface GoalService {
 
     ApplicationResponse<GoalResponse> findById(Long goalId);
 
-    ApplicationResponse<Page<GoalResponse>> findAllByUser(String userId, Long goalCategoryId,
+    ApplicationResponse<Page<GoalResponse>> findAllByUserCategory(String userId, Long goalCategoryId,
         Pageable pageable);
 
     ApplicationResponse<GoalResponse> update(GoalUpdateRequest request, Long goalId, String userId);
 
     ApplicationResponse<Void> delete(Long goalId, String userId);
+
+    ApplicationResponse<Page<GoalResponse>> findAllByUser(String userId, Pageable pageable);
 }

--- a/src/main/java/com/example/pomeserver/domain/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/service/GoalServiceImpl.java
@@ -18,6 +18,9 @@ import com.example.pomeserver.domain.user.entity.User;
 import com.example.pomeserver.domain.user.exception.excute.UserNotFoundException;
 import com.example.pomeserver.domain.user.repository.UserRepository;
 import com.example.pomeserver.global.dto.response.ApplicationResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -79,7 +82,7 @@ public class GoalServiceImpl implements GoalService{
     }
 
     @Override
-    public ApplicationResponse<Page<GoalResponse>> findAllByUser(
+    public ApplicationResponse<Page<GoalResponse>> findAllByUserCategory(
             String userId,
         Long goalCategoryId, Pageable pageable)
     {
@@ -134,5 +137,15 @@ public class GoalServiceImpl implements GoalService{
         goalRepository.deleteById(goalId);
 
         return ApplicationResponse.ok();
+    }
+
+    @Override
+    public ApplicationResponse<Page<GoalResponse>> findAllByUser(String userId, Pageable pageable) {
+
+        // (1) User 데이터 조회
+        User user = userRepository.findByUserId(userId).orElseThrow(UserNotFoundException::new);
+
+        // (2) User가 갖는 목표 카테고리로부터 목표 전체 조회
+        return ApplicationResponse.ok(goalRepository.findAllByUser(user, pageable).map(GoalResponse::toDto));
     }
 }

--- a/src/main/java/com/example/pomeserver/domain/user/entity/User.java
+++ b/src/main/java/com/example/pomeserver/domain/user/entity/User.java
@@ -33,6 +33,9 @@ public class User {
     private String image;
 
     @OneToMany(mappedBy="user", cascade=ALL)
+    private List<Goal> goals = new ArrayList<>();
+
+    @OneToMany(mappedBy="user", cascade=ALL)
     private List<Record> records = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = ALL)
@@ -53,6 +56,10 @@ public class User {
         this.nickname = nickname;
         this.phoneNum = phoneNum;
         this.image = image;
+    }
+
+    public void addGoal(Goal goal) {
+        this.goals.add(goal);
     }
 
     public void addGoalCategory(GoalCategory goalCategory) {


### PR DESCRIPTION
## 의논하고 싶은 사항

User -> GoalCategory -> Goal 이 플로우를 생각하고 기존의 User<>Goal의 연관관계를 삭제했었습니다.
프론트엔드 측에서 유저가 갖는 모든 목표를 조회할 수 있는 API 를 추가로 요청하였고, 이에 따라 현재의 ERD 상태에서 개발하고자 했습니다.

[고민했던 점]
UserId를 통해 유저가 갖는 모든 카테고리와 그에 연관된 목표를 하나의 쿼리로 조회할 수 있습니다. 
```` bash
List<GoalCategory> lists = userRepository.findById(userId).get().getGoalCategories(); // ==> 카테고리 리스트

for (GoalCategory ca : lists ) {
   ca.getGoals(); // ==> 하나의 카테고리가 갖는 목표 리스트
}

````

위에서 조회된 것을 하나의 List<Goal> 형태로 만들어 map(GoalResponse::toDto) 하려 했으나, Page<T> 형태의 가공처리까지 더해졌을 때의 성능상의 이점이 있을까에 대한 생각이 들었습니다.

[변경한 점]
User<>Goal의 연관관계를 다시 넣어줌으로써 위의 과정이 한 줄로 처리 될 수 있을 거 같아 연관관계를 넣은 상태로 기능 개발을 했습니다.
혹시 좀 더 좋은 아이디어가 있을까요?