### PR TITLE
[feature/goal service] 스웨거 이슈 해결 및 목표 응답 날짜 포맷팅 지정

### DIFF
--- a/src/main/java/com/example/pomeserver/domain/goal/dto/response/GoalResponse.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/dto/response/GoalResponse.java
@@ -1,7 +1,9 @@
 package com.example.pomeserver.domain.goal.dto.response;
 
 import com.example.pomeserver.domain.goal.entity.Goal;
-import java.sql.Date;
+import java.util.Date;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,10 +32,17 @@ public class GoalResponse {
         response.price = goal.getPrice();
         response.isPublic = goal.isPublic();
 
-        if (LocalDate.parse(goal.getEndDate()).isBefore(LocalDate.now())) {
-            response.isEnd = true;
-        } else
-            response.isEnd = goal.getRecords().isEmpty();
+        SimpleDateFormat fromFormat = new SimpleDateFormat("yyyy.MM.dd");
+        try {
+            Date fromDate = fromFormat.parse(goal.getEndDate());
+            Date now = new Date();
+            if (fromDate.before(now)) {
+                response.isEnd = true;
+            } else
+                response.isEnd = goal.getRecords().isEmpty();
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
 
         response.nickname = goal.getGoalCategory().getUser().getNickname();
         return response;

--- a/src/main/java/com/example/pomeserver/global/util/authResolver/UserId.java
+++ b/src/main/java/com/example/pomeserver/global/util/authResolver/UserId.java
@@ -4,8 +4,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import springfox.documentation.annotations.ApiIgnore;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@ApiIgnore
 public @interface UserId {
 }


### PR DESCRIPTION
## Notice

- Swagger에서 userId 값 입력을 UI 상에서 노출하지 않도록 @ApiIgnore 어노테이션 추가했습니다.
- 목표 응답 객체에 `목표 종료 상태 여부` 값을 추가했습니다

목표 종료는 아래 2가지 케이스에 한정했습니다.
1. 목표 종료 날짜가 오늘날짜보다 이전인 경우
2. 목표에 대한 소비 기록이 없는 경우

위의 2가지 경우에 해당한다면, isEnd = true로 반환합니다.

날짜 비교를 위해 toDto() 내에 yyyy.MM.dd 날짜 포맷팅을 지정하여 비교하도록 하였습니다. ( 앞선 PR에서는 포맷팅을 강제하지 않았기 때문에 기본 포맷팅인 yyyy-MM-dd 형식으로 데이터를 전송하지 않을 경우, 파싱 에러가 발생했습니다. )
