### PR TITLE
[feature/goal service] 목표 종료하기 API 기능 개발

### DIFF
--- a/src/main/java/com/example/pomeserver/domain/goal/controller/GoalController.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/controller/GoalController.java
@@ -38,6 +38,8 @@ public class GoalController {
      *
      * @author 이은비
      */
+    @Operation(summary = "목표 생성하기",
+                description = "사용자가 목표를 생성한다.")
     @Auth
     @PostMapping
     public ApplicationResponse<GoalResponse> create(
@@ -47,8 +49,8 @@ public class GoalController {
         return goalService.create(request, userId);
     }
 
-    @Operation(summary = "목표 한개 조회",
-            description = "사용자가 목표 하나를 조회한다.")
+    @Operation(summary = "목표 한개 조회하기",
+            description = "사용자가 목표ID를 통해 특정 목표를 조회한다.")
     /**
      * Goal 단일 조회.
      *
@@ -65,6 +67,8 @@ public class GoalController {
      *
      * @author 이은비
      */
+    @Operation(summary = "특정 목표 카테고리에 따른 목표 리스트 조회하기",
+        description = "사용자가 보유한 목표 카테고리 리스트 중 목표 카테고리 ID를 통해 특정 목표 카테고리에 속하는 목표 리스트 조회한다.")
     @Auth
     @GetMapping("/category/{goalCategoryId}")
     public ApplicationResponse<Page<GoalResponse>> findAllByUserCategory(
@@ -80,6 +84,11 @@ public class GoalController {
      *
      * @author 이은비
      */
+    @Operation(summary = "사용자가 보유한 목표 리스트 조회하기",
+        description = "사용자가 보유한 모든 목표 리스트를 조회한다. " +
+                        "이때 클라이언트는 반드시 쿼리스트링으로 sort를 명시해주어야 한다. " +
+                        "ex) /api/v1/goals/users?sort=endDate,desc" +
+                        " --> 목표 종료일자 최신순으로 조회하기")
     @Auth
     @GetMapping("/users")
     public ApplicationResponse<Page<GoalResponse>> findAllByUser(
@@ -94,6 +103,8 @@ public class GoalController {
      *
      * @author 이은비
      */
+    @Operation(summary = "목표 수정하기",
+        description = "사용자가 생성할 때 작성했던 데이터를 수정한다. (종료, 한 줄 코멘트, 소비금액)을 제외하고 수정할 수 있다.")
     @Auth
     @PutMapping("/{goalId}")
     public ApplicationResponse<GoalResponse> update(
@@ -109,6 +120,8 @@ public class GoalController {
      *
      * @author 이은비
      */
+    @Operation(summary = "목표 삭제하기",
+        description = "사용자가 목표를 삭제한다.")
     @Auth
     @DeleteMapping("/{goalId}")
     public ApplicationResponse<Void> delete(
@@ -123,6 +136,10 @@ public class GoalController {
      *
      * @author 이은비
      * */
+    @Operation(summary = "목표 종료하기",
+        description = "사용자가 목표를 종료한다. 종료 시, 한줄 코멘트를 입력해야 한다." +
+                        " 목표 종료일자가 오늘보다 이전이거나 소비 기록이 하나도 없을 경우 종료할 수 있다." +
+                        " 목표가 가진 소비 기록에 대해 2번째 감정을 기록하지 않은 경우가 있다면, 목표를 종료할 수 없다.")
     @Auth
     @PutMapping("/end/{goalId}")
     public ApplicationResponse<GoalResponse> terminate(
@@ -133,6 +150,13 @@ public class GoalController {
         return goalService.terminate(goalId, request, userId);
     }
 
+    /**
+     * 사용자의 종료된 목표 리스트 조회.
+     *
+     * @author 이은비
+     * */
+    @Operation(summary = "종료된 목표 조회하기",
+        description = "사용자가 종료된 목표를 조회한다.")
     @Auth
     @GetMapping("/users/end")
     public ApplicationResponse<Page<GoalResponse>> findByUsersAndEnd(

--- a/src/main/java/com/example/pomeserver/domain/goal/controller/GoalController.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/controller/GoalController.java
@@ -1,6 +1,7 @@
 package com.example.pomeserver.domain.goal.controller;
 
 import com.example.pomeserver.domain.goal.dto.request.GoalCreateRequest;
+import com.example.pomeserver.domain.goal.dto.request.GoalTerminateRequest;
 import com.example.pomeserver.domain.goal.dto.request.GoalUpdateRequest;
 import com.example.pomeserver.domain.goal.dto.response.GoalResponse;
 import com.example.pomeserver.domain.goal.service.GoalService;
@@ -115,5 +116,20 @@ public class GoalController {
             @ApiIgnore @UserId String userId)
     {
         return goalService.delete(goalId, userId);
+    }
+
+    /**
+     * Goal 종료.
+     *
+     * @author 이은비
+     * */
+    @Auth
+    @PutMapping("/end/{goalId}")
+    public ApplicationResponse<GoalResponse> terminate(
+        @PathVariable Long goalId,
+        @RequestBody GoalTerminateRequest request,
+        @ApiIgnore @UserId String userId
+    ) {
+        return goalService.terminate(goalId, request, userId);
     }
 }

--- a/src/main/java/com/example/pomeserver/domain/goal/controller/GoalController.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/controller/GoalController.java
@@ -132,4 +132,13 @@ public class GoalController {
     ) {
         return goalService.terminate(goalId, request, userId);
     }
+
+    @Auth
+    @GetMapping("/users/end")
+    public ApplicationResponse<Page<GoalResponse>> findByUsersAndEnd(
+        @ApiIgnore @UserId String userId,
+        Pageable pageable
+    ) {
+        return goalService.findByUserAndEnd(userId, pageable);
+    }
 }

--- a/src/main/java/com/example/pomeserver/domain/goal/dto/request/GoalTerminateRequest.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/dto/request/GoalTerminateRequest.java
@@ -1,0 +1,15 @@
+package com.example.pomeserver.domain.goal.dto.request;
+
+import io.swagger.annotations.ApiModel;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@ApiModel("목표 종료 요청 객체")
+@NoArgsConstructor
+@Data
+public class GoalTerminateRequest {
+
+  @NotNull(message = "한 줄 코멘트는 필수값입니다.")
+  private String oneLineComment;
+}

--- a/src/main/java/com/example/pomeserver/domain/goal/dto/response/GoalResponse.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/dto/response/GoalResponse.java
@@ -1,6 +1,7 @@
 package com.example.pomeserver.domain.goal.dto.response;
 
 import com.example.pomeserver.domain.goal.entity.Goal;
+import com.example.pomeserver.domain.record.entity.Record;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,6 +33,10 @@ public class GoalResponse {
         response.isPublic = goal.isPublic();
         response.isEnd = goal.isEnd();
         response.oneLineComment = goal.getOneLineComment();
+        // Goal이 갖는 Record의 usePrice의 합으로 갱신
+        for (Record record : goal.getRecords()) {
+            goal.addUsePrice(record.getUsePrice());
+        }
         response.usePrice = goal.getUsePrice();
         response.nickname = goal.getGoalCategory().getUser().getNickname();
         return response;

--- a/src/main/java/com/example/pomeserver/domain/goal/dto/response/GoalResponse.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/dto/response/GoalResponse.java
@@ -1,10 +1,6 @@
 package com.example.pomeserver.domain.goal.dto.response;
 
 import com.example.pomeserver.domain.goal.entity.Goal;
-import java.util.Date;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,7 +15,10 @@ public class GoalResponse {
     private int price;
     private Boolean isPublic;
 
-    private Boolean isEnd; // endDate가 지났거나 소비기록이 없거나
+    private Boolean isEnd; // 종료인지 아닌지 상태
+    private int usePrice; // 사용금액
+
+    private String oneLineComment; // 한줄 코멘트
     private String nickname;
 
     public static GoalResponse toDto(Goal goal){
@@ -31,19 +30,9 @@ public class GoalResponse {
         response.oneLineMind = goal.getOneLineMind();
         response.price = goal.getPrice();
         response.isPublic = goal.isPublic();
-
-        SimpleDateFormat fromFormat = new SimpleDateFormat("yyyy.MM.dd");
-        try {
-            Date fromDate = fromFormat.parse(goal.getEndDate());
-            Date now = new Date();
-            if (fromDate.before(now)) {
-                response.isEnd = true;
-            } else
-                response.isEnd = goal.getRecords().isEmpty();
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
-
+        response.isEnd = goal.isEnd();
+        response.oneLineComment = goal.getOneLineComment();
+        response.usePrice = goal.getUsePrice();
         response.nickname = goal.getGoalCategory().getUser().getNickname();
         return response;
     }

--- a/src/main/java/com/example/pomeserver/domain/goal/entity/Goal.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/entity/Goal.java
@@ -76,8 +76,6 @@ public class Goal extends DateBaseEntity {
         this.oneLineMind = oneLineMind;
         this.price = price;
         this.isPublic = isPublic;
-        this.isEnd = false; // 최초 생성 시, 종료가 아닌 상태
-        this.usePrice = 0; // 최초 생성 시, 사용금액 0원
     }
 
     public static Goal toUpdateEntity(
@@ -120,12 +118,6 @@ public class Goal extends DateBaseEntity {
         this.addGoalCategory(goalCategory);
     }
 
-    /**
-     * 기록 생성 시, 사용 금액 누적 함수
-     * */
-    public void editUsePrice(int usePrice) {
-        this.usePrice += usePrice;
-    }
 
     /**
     * 목표 종료 시, 데이터 변경하는 함수

--- a/src/main/java/com/example/pomeserver/domain/goal/entity/Goal.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/entity/Goal.java
@@ -2,6 +2,7 @@ package com.example.pomeserver.domain.goal.entity;
 
 import static javax.persistence.CascadeType.ALL;
 
+import com.example.pomeserver.domain.goal.dto.request.GoalTerminateRequest;
 import com.example.pomeserver.domain.record.entity.Record;
 import com.example.pomeserver.domain.user.entity.User;
 import com.example.pomeserver.global.entity.DateBaseEntity;
@@ -40,11 +41,17 @@ public class Goal extends DateBaseEntity {
     @OneToMany(mappedBy="goal", cascade=ALL)
     private List<Record> records = new ArrayList<>();
 
-    private String startDate;
-    private String endDate;
-    private String oneLineMind;
-    private int price;
-    private boolean isPublic;
+    private String startDate; // 시작일자
+    private String endDate; // 목표일자
+    private String oneLineMind; // 한줄 다짐
+    private int price; // 목표 금액
+    private boolean isPublic; // 공개여부
+
+    private boolean isEnd; // 종료여부
+
+    private int usePrice; // 사용 금액
+
+    private String oneLineComment; // 한줄 코멘트
 
     public void addRecord(Record record) {
         this.records.add(record);
@@ -69,6 +76,8 @@ public class Goal extends DateBaseEntity {
         this.oneLineMind = oneLineMind;
         this.price = price;
         this.isPublic = isPublic;
+        this.isEnd = false; // 최초 생성 시, 종료가 아닌 상태
+        this.usePrice = 0; // 최초 생성 시, 사용금액 0원
     }
 
     public static Goal toUpdateEntity(
@@ -102,10 +111,27 @@ public class Goal extends DateBaseEntity {
         this.price = editGoal.getPrice();
         this.isPublic = editGoal.isPublic();
         if(!Objects.equals(this.getGoalCategory().getId(), editGoal.getGoalCategory().getId())) editGoalCategory(editGoal.getGoalCategory());
+        this.isEnd = editGoal.isEnd;
+        this.oneLineComment = editGoal.oneLineComment;
     }
 
     private void editGoalCategory(GoalCategory goalCategory){
         this.goalCategory.removeGoal(this);
         this.addGoalCategory(goalCategory);
+    }
+
+    /**
+     * 기록 생성 시, 사용 금액 누적 함수
+     * */
+    public void editUsePrice(int usePrice) {
+        this.usePrice += usePrice;
+    }
+
+    /**
+    * 목표 종료 시, 데이터 변경하는 함수
+    * */
+    public void terminate(GoalTerminateRequest request) {
+        this.isEnd = true;
+        this.oneLineComment = request.getOneLineComment();
     }
 }

--- a/src/main/java/com/example/pomeserver/domain/goal/entity/Goal.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/entity/Goal.java
@@ -126,4 +126,8 @@ public class Goal extends DateBaseEntity {
         this.isEnd = true;
         this.oneLineComment = request.getOneLineComment();
     }
+
+    public void addUsePrice(int usePrice) {
+        this.usePrice += usePrice;
+    }
 }

--- a/src/main/java/com/example/pomeserver/domain/goal/exception/GoalExceptionList.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/exception/GoalExceptionList.java
@@ -14,6 +14,8 @@ public enum GoalExceptionList {
     GOAL_CATEGORY_DUPLICATION("G0004", HttpStatus.BAD_REQUEST, "해당 이름을 가진 Goal Category가 이미 존재합니다."),
 
     GOAL_CATEGORY_LIST_SIZE_OUT_OF_INDEX("G0005", HttpStatus.CONFLICT, "목표 카테고리의 개수가 10개를 초과합니다."),
+    GOAL_ALREADY_END("G0006", HttpStatus.BAD_REQUEST, "이미 종료된 목표입니다."),
+    GOAL_CAN_NOT_END("G0007", HttpStatus.BAD_REQUEST, "2번째 감정이 없는 기록이 포함된 목표입니다."),
     ;
 
     public final String CODE;

--- a/src/main/java/com/example/pomeserver/domain/goal/exception/excute/GoalAlreadyEndException.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/exception/excute/GoalAlreadyEndException.java
@@ -1,0 +1,12 @@
+package com.example.pomeserver.domain.goal.exception.excute;
+
+import static com.example.pomeserver.domain.goal.exception.GoalExceptionList.GOAL_ALREADY_END;
+
+import com.example.pomeserver.domain.goal.exception.GoalException;
+
+public class GoalAlreadyEndException extends GoalException {
+
+  public GoalAlreadyEndException() {
+    super(GOAL_ALREADY_END.getCODE(), GOAL_ALREADY_END.httpStatus, GOAL_ALREADY_END.getMESSAGE());
+  }
+}

--- a/src/main/java/com/example/pomeserver/domain/goal/exception/excute/GoalCanNotEndException.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/exception/excute/GoalCanNotEndException.java
@@ -1,0 +1,12 @@
+package com.example.pomeserver.domain.goal.exception.excute;
+
+import static com.example.pomeserver.domain.goal.exception.GoalExceptionList.GOAL_CAN_NOT_END;
+
+import com.example.pomeserver.domain.goal.exception.GoalException;
+
+public class GoalCanNotEndException extends GoalException {
+
+  public GoalCanNotEndException() {
+    super(GOAL_CAN_NOT_END.getCODE(), GOAL_CAN_NOT_END.httpStatus, GOAL_CAN_NOT_END.getMESSAGE());
+  }
+}

--- a/src/main/java/com/example/pomeserver/domain/goal/repository/GoalRepository.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/repository/GoalRepository.java
@@ -15,4 +15,6 @@ public interface GoalRepository extends JpaRepository<Goal, Long> {
     Page<Goal> findAllByGoalCategory(GoalCategory goalCategory, Pageable pageable);
 
     Page<Goal> findAllByUser(User user, Pageable pageable);
+
+    Page<Goal> findAllByUserAndIsEnd(User user, boolean isEnd, Pageable pageable);
 }

--- a/src/main/java/com/example/pomeserver/domain/goal/service/GoalService.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/service/GoalService.java
@@ -23,4 +23,6 @@ public interface GoalService {
     ApplicationResponse<Page<GoalResponse>> findAllByUser(String userId, Pageable pageable);
 
   ApplicationResponse<GoalResponse> terminate(Long goalId, GoalTerminateRequest request, String userId);
+
+  ApplicationResponse<Page<GoalResponse>> findByUserAndEnd(String userId, Pageable pageable);
 }

--- a/src/main/java/com/example/pomeserver/domain/goal/service/GoalService.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/service/GoalService.java
@@ -1,6 +1,7 @@
 package com.example.pomeserver.domain.goal.service;
 
 import com.example.pomeserver.domain.goal.dto.request.GoalCreateRequest;
+import com.example.pomeserver.domain.goal.dto.request.GoalTerminateRequest;
 import com.example.pomeserver.domain.goal.dto.request.GoalUpdateRequest;
 import com.example.pomeserver.domain.goal.dto.response.GoalResponse;
 import com.example.pomeserver.global.dto.response.ApplicationResponse;
@@ -20,4 +21,6 @@ public interface GoalService {
     ApplicationResponse<Void> delete(Long goalId, String userId);
 
     ApplicationResponse<Page<GoalResponse>> findAllByUser(String userId, Pageable pageable);
+
+  ApplicationResponse<GoalResponse> terminate(Long goalId, GoalTerminateRequest request, String userId);
 }

--- a/src/main/java/com/example/pomeserver/domain/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/service/GoalServiceImpl.java
@@ -176,4 +176,13 @@ public class GoalServiceImpl implements GoalService{
         return ApplicationResponse.ok(GoalResponse.toDto(saved));
     }
 
+    @Override
+    public ApplicationResponse<Page<GoalResponse>> findByUserAndEnd(String userId, Pageable pageable) {
+        // (1) User 데이터 조회
+        User user = userRepository.findByUserId(userId).orElseThrow(UserNotFoundException::new);
+
+        // (2) 유저가 보유한 종료된 목표 조회
+
+        return ApplicationResponse.ok(goalRepository.findAllByUserAndIsEnd(user, true, pageable).map(GoalResponse::toDto));
+    }
 }

--- a/src/main/java/com/example/pomeserver/domain/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/service/GoalServiceImpl.java
@@ -55,21 +55,16 @@ public class GoalServiceImpl implements GoalService{
         }
 
         // (2) 유저가 보유하고 있는 카테고리명 중복 확인
-        boolean distinct = user.getGoalCategories().stream()
-            .anyMatch(goalCategory -> goalCategory.getName().equals(request.getName()));
-        if (distinct) {
-            throw new GoalCategoryDuplicationException();
-        }
+        // 중복이라면 목표 카테고리의 목표 리스트에 추가 || 중복이 아니라면 목표 카테고리 새로 생성
+        GoalCategory distinct = user.getGoalCategories().stream()
+            .filter(goalCategory -> goalCategory.getName().equals(request.getName()))
+            .findFirst()
+            .orElse(goalCategoryRepository.save(goalCategoryAssembler.toEntity(request.getName(), user)));
 
-        // (3) 카테고리 생성
-        GoalCategory goalCategory = goalCategoryAssembler.toEntity(request.getName(), user);
-        GoalCategory saved = goalCategoryRepository.save(goalCategory);
+        // (3) DTO <-> Entity
+        Goal goal = goalAssembler.toEntity(request, distinct);
 
-
-        // (2) DTO <-> Entity
-        Goal goal = goalAssembler.toEntity(request, saved);
-
-        // (3) Goal 저장
+        // (4) Goal 저장
         Goal savedGoal = goalRepository.save(goal);
 
         return ApplicationResponse.create(GoalResponse.toDto(savedGoal));

--- a/src/main/java/com/example/pomeserver/domain/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/service/GoalServiceImpl.java
@@ -3,10 +3,13 @@ package com.example.pomeserver.domain.goal.service;
 import com.example.pomeserver.domain.goal.dto.assembler.GoalAssembler;
 import com.example.pomeserver.domain.goal.dto.assembler.GoalCategoryAssembler;
 import com.example.pomeserver.domain.goal.dto.request.GoalCreateRequest;
+import com.example.pomeserver.domain.goal.dto.request.GoalTerminateRequest;
 import com.example.pomeserver.domain.goal.dto.request.GoalUpdateRequest;
 import com.example.pomeserver.domain.goal.dto.response.GoalResponse;
 import com.example.pomeserver.domain.goal.entity.Goal;
 import com.example.pomeserver.domain.goal.entity.GoalCategory;
+import com.example.pomeserver.domain.goal.exception.excute.GoalAlreadyEndException;
+import com.example.pomeserver.domain.goal.exception.excute.GoalCanNotEndException;
 import com.example.pomeserver.domain.goal.exception.excute.GoalCategoryDuplicationException;
 import com.example.pomeserver.domain.goal.exception.excute.GoalCategoryListSizeException;
 import com.example.pomeserver.domain.goal.exception.excute.GoalCategoryNotFoundException;
@@ -14,13 +17,11 @@ import com.example.pomeserver.domain.goal.exception.excute.GoalNotFoundException
 import com.example.pomeserver.domain.goal.exception.excute.ThisGoalIsNotByThisUserException;
 import com.example.pomeserver.domain.goal.repository.GoalCategoryRepository;
 import com.example.pomeserver.domain.goal.repository.GoalRepository;
+import com.example.pomeserver.domain.record.entity.Record;
 import com.example.pomeserver.domain.user.entity.User;
 import com.example.pomeserver.domain.user.exception.excute.UserNotFoundException;
 import com.example.pomeserver.domain.user.repository.UserRepository;
 import com.example.pomeserver.global.dto.response.ApplicationResponse;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -148,4 +149,36 @@ public class GoalServiceImpl implements GoalService{
         // (2) User가 갖는 목표 카테고리로부터 목표 전체 조회
         return ApplicationResponse.ok(goalRepository.findAllByUser(user, pageable).map(GoalResponse::toDto));
     }
+
+    @Transactional
+    @Override
+    public ApplicationResponse<GoalResponse> terminate(Long goalId, GoalTerminateRequest request,
+        String userId) {
+        // (1) Goal 데이터 조회
+        Goal goal = goalRepository.findById(goalId).orElseThrow(GoalNotFoundException::new);
+
+        // (2) User 권한 조회
+        if(!goal.getGoalCategory().getUser().getUserId().equals(userId)) throw new ThisGoalIsNotByThisUserException();
+
+        // (3) 종료 상태여부 확인
+        if(goal.isEnd()) {
+            throw new GoalAlreadyEndException();
+        }
+
+        // (4) 종료일자가 오늘보다 이전인지 확인 -> 소비 기록이 없어도 종료 가능하기에 해당 로직 제외
+
+        // (5) 목표가 보유한 모든 기록이 2번째 감정까지 남겼는지 확인
+        for (Record record : goal.getRecords()){
+            if (record.getEmotionRecords().size() == 1) {
+                throw new GoalCanNotEndException();
+            }
+        }
+
+        // (6) 목표 종료 상태 수정 및 저장
+        goal.terminate(request);
+        Goal saved = goalRepository.save(goal);
+
+        return ApplicationResponse.ok(GoalResponse.toDto(saved));
+    }
+
 }

--- a/src/main/java/com/example/pomeserver/domain/record/controller/RecordController.java
+++ b/src/main/java/com/example/pomeserver/domain/record/controller/RecordController.java
@@ -148,7 +148,7 @@ public class RecordController {
     @Auth
     @PutMapping("/{recordId}")
     public ApplicationResponse<RecordResponse> update(
-            RecordUpdateRequest request,
+            @RequestBody RecordUpdateRequest request,
             @PathVariable Long recordId,
             @ApiIgnore @UserId String userId)
     {


### PR DESCRIPTION
## Notice

- 목표 종료여부를 위한 속성값을 추가 및 종료하기 API 기능 개발
- 스웨거에 보여지는 description 추가

## Question
[기존]
목표 카테고리와 목표가 1:N 관계라고 이해해서 목표 카테고리를 먼저 생성하고 목표가 생성되는 프로세스로 로직을 개발했습니다. 
하지만, 목표 카테고리가 단순히 목표의 이름을 나타내는 속성이라는 점을 놓쳤습니다. 
그래서 목표를 생성할 때, 그 내부 로직 안에 목표 카테고리의 중복 여부를 검사하고 중복이면 오류를 던지고 아닐 경우 목표 카테고리를 생성한 뒤에 목표를 생성하도록 했습니다.

[변경사항]
위와 같이 로직을 구성할 경우, 유저가 목표를 삭제하지 않는 한 동일한 이름의 목표가 종료 되었음에도 같은 이름의 새로운 목표를 만들 수 없습니다. 따라서 목표 카테고리와 목표 연관 관계를 기존처럼 1:N의 관계로 유지하되 목표를 생성할 때 , 목표 카테고리가 중복일 경우 목표 카테고리 아래 목표 리스트에 추가하는 식으로 로직을 변경하였습니다.

**1)기존 처럼 중복일 경우 오류를 던지는 것**과 **2)중복일 경우, 목표 카테고리 아래 목표 리스트에 추가하는 것** 중 어느 쪽이 더 나은지 의견 부탁드려요!