### PR TITLE
[hotfix/goal-service] 목표 생성 시, 유저가 가질 수 있는 목표 카테고리 개수 제한 조건 수정

### DIFF
--- a/src/main/java/com/example/pomeserver/domain/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/example/pomeserver/domain/goal/service/GoalServiceImpl.java
@@ -22,6 +22,7 @@ import com.example.pomeserver.domain.user.entity.User;
 import com.example.pomeserver.domain.user.exception.excute.UserNotFoundException;
 import com.example.pomeserver.domain.user.repository.UserRepository;
 import com.example.pomeserver.global.dto.response.ApplicationResponse;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -49,7 +50,9 @@ public class GoalServiceImpl implements GoalService {
     // (1) 카테고리 리스트의 개수 초과 여부 확인
     User user = userRepository.findByUserId(userId).orElseThrow(UserNotFoundException::new);
 
-    if (user.getGoalCategories().size() == 10) {
+    // 활성화된 목표 + 유저가 종료 처리하지 않은 기한이 지난 목표 = 10개 제한
+    // isEnd -> 유저가 종료처리한 목표
+    if (user.getGoals().stream().filter(goal -> !goal.isEnd()).count() == 10) {
       throw new GoalCategoryListSizeException();
     }
 


### PR DESCRIPTION
[기존]
유저가 갖는 모든 목표의 개수 = 10개 제한
[변경]
활성화된 목표 + 유저가 종료 처리하지 않은 기한이 지난 목표 = 10개 제한

Goal의 isEnd 속성값으로 유저가 직접 종료시켰는지에 대한 상태를 구분합니다. 따라서 isEnd가 false인 목표에 대해서만 개수를 집계하여 10개 이하인지 확인하는 로직으로 변경하였습니다.