### PR TITLE
[infra/build-test] PROD CI 워크플로우 롤백

### DIFF
--- a/.github/workflows/build-test-prod.yml
+++ b/.github/workflows/build-test-prod.yml
@@ -53,13 +53,6 @@ jobs:
           echo "${{ secrets.PROPERTIES_TEST }}" > ./application-secret.yml
         shell: bash
 
-      # 6) 테스트
-      - name: Test with Gradle
-        run: ./gradlew --info test
-
-        # 7) 테스트 후 결과 파일 생성
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        if: ${{ always() }}  # 테스트가 실패하여도 Report를 보기 위해 `always`로 설정
-        with:
-          files: build/test-results/**/*.xml
+      # 6) 빌드 테스트
+      - name: Test with gradle
+        run:  ./gradlew clean build


### PR DESCRIPTION
## Question
DEV CI 워크 플로우에서 테스트 코드 빌드와 그에 대한 레포팅이 이루어진 뒤에 PROD로 배포가 되기 때문에 PROD CI 워크플로우는 기존 플로우로 진행하면 어떨까합니다.!