### PR TITLE
[feature/edit-DTO] Record 생성 시, 코멘트 글자수 제한(20자 -> 150자) 수정

### DIFF
--- a/src/main/java/com/example/pomeserver/domain/record/dto/request/RecordCreateRequest.java
+++ b/src/main/java/com/example/pomeserver/domain/record/dto/request/RecordCreateRequest.java
@@ -32,7 +32,7 @@ public class RecordCreateRequest {
     private String useDate;   // "2023.01.13"
 
     @ApiModelProperty(value = "기록 코멘트", example = "이런저런 소비를 하였다. ^.^", required = true, dataType = "string")
-    @Size(max = 21, message = "코멘트는 20자 이하만 가능합니다.")
+    @Size(max = 151, message = "코멘트는 150자 이하만 가능합니다.")
     private String useComment;
 }
 


### PR DESCRIPTION
피그마 상에서 기록 생성 시, useComment의 글자 수 제한을 150자로 설정되어 있어 아래와 같이 변경하였습니다.

[기존]
20자 제한
[변경]
150자 제한